### PR TITLE
Add missing Nomad configuration

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -24,7 +24,7 @@ func Get() (*Config, error) {
 	}
 
 	cfg = &Config{
-		BindAddr:                   "localhost:29100",
+		BindAddr:                   ":29100",
 		GracefulShutdownTimeout:    5 * time.Second,
 		HealthCheckInterval:        30 * time.Second,
 		HealthCheckCriticalTimeout: 90 * time.Second,

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -23,7 +23,7 @@ func TestConfig(t *testing.T) {
 				configuration, err = Get() // This Get() is only called once, when inside this function
 				So(err, ShouldBeNil)
 				So(configuration, ShouldResemble, &Config{
-					BindAddr:                   "localhost:29100",
+					BindAddr:                   ":29100",
 					GracefulShutdownTimeout:    5 * time.Second,
 					HealthCheckInterval:        30 * time.Second,
 					HealthCheckCriticalTimeout: 90 * time.Second,

--- a/dp-legacy-cache-api.nomad
+++ b/dp-legacy-cache-api.nomad
@@ -40,6 +40,7 @@ job "dp-legacy-cache-api" {
 
         image = "{{ECR_URL}}:concourse-{{REVISION}}"
 
+        ports = ["http"]
       }
 
       service {
@@ -60,7 +61,9 @@ job "dp-legacy-cache-api" {
         memory = "{{WEB_RESOURCE_MEM}}"
 
         network {
-          port "http" {}
+          port "http" {
+            to = 29100
+          }
         }
       }
 
@@ -103,6 +106,8 @@ job "dp-legacy-cache-api" {
         args = ["./dp-legacy-cache-api"]
 
         image = "{{ECR_URL}}:concourse-{{REVISION}}"
+
+        ports = ["http"]
       }
 
       service {
@@ -123,7 +128,9 @@ job "dp-legacy-cache-api" {
         memory = "{{PUBLISHING_RESOURCE_MEM}}"
 
         network {
-          port "http" {}
+          port "http" {
+            to = 29100
+          }
         }
       }
 

--- a/dp-legacy-cache-api.nomad
+++ b/dp-legacy-cache-api.nomad
@@ -26,50 +26,56 @@ job "dp-legacy-cache-api" {
       mode     = "delay"
     }
 
+    network {
+      port "http" {
+        to = 29100
+      }
+    }
+
+    service {
+      name = "dp-legacy-cache-api"
+      port = "http"
+      tags = ["web"]
+
+      check {
+        type     = "http"
+        path     = "/health"
+        interval = "10s"
+        timeout  = "2s"
+      }
+    }
+
     task "dp-legacy-cache-api-web" {
       driver = "docker"
 
-      artifact {
-        source = "s3::https://s3-eu-west-2.amazonaws.com/{{DEPLOYMENT_BUCKET}}/dp-legacy-cache-api/{{PROFILE}}/{{RELEASE}}.tar.gz"
-      }
-
       config {
-        command = "${NOMAD_TASK_DIR}/start-task"
-
-        args = ["./dp-legacy-cache-api"]
-
-        image = "{{ECR_URL}}:concourse-{{REVISION}}"
-
-        ports = ["http"]
-      }
-
-      service {
-        name = "dp-legacy-cache-api"
-        port = "http"
-        tags = ["web"]
-
-        check {
-          type     = "http"
-          path     = "/health"
-          interval = "10s"
-          timeout  = "2s"
-        }
+        command = "./dp-legacy-cache-api"
+        image   = "{{ECR_URL}}:concourse-{{REVISION}}"
+        ports   = ["http"]
       }
 
       resources {
         cpu    = "{{WEB_RESOURCE_CPU}}"
         memory = "{{WEB_RESOURCE_MEM}}"
-
-        network {
-          port "http" {
-            to = 29100
-          }
-        }
       }
 
       template {
-        source      = "${NOMAD_TASK_DIR}/vars-template"
-        destination = "${NOMAD_TASK_DIR}/vars"
+        data = <<EOH
+        # Configs based on environment (e.g. export BIND_ADDR=":{{ env "NOMAD_PORT_http" }}")
+        # or static (e.g. export BIND_ADDR=":8080")
+
+        # Secret configs read from vault
+        {{ with (secret (print "secret/" (env "NOMAD_TASK_NAME"))) }}
+        {{ range $key, $value := .Data }}
+        export {{ $key }}="{{ $value }}"
+        {{ end }}
+        {{ end }}
+        EOH
+
+        destination = "secrets/app.env"
+        env         = true
+        splay       = "1m"
+        change_mode = "restart"
       }
 
       vault {
@@ -93,50 +99,56 @@ job "dp-legacy-cache-api" {
       mode     = "delay"
     }
 
+    network {
+      port "http" {
+        to = 29100
+      }
+    }
+
+    service {
+      name = "dp-legacy-cache-api"
+      port = "http"
+      tags = ["publishing"]
+
+      check {
+        type     = "http"
+        path     = "/health"
+        interval = "10s"
+        timeout  = "2s"
+      }
+    }
+
     task "dp-legacy-cache-api-publishing" {
       driver = "docker"
 
-      artifact {
-        source = "s3::https://s3-eu-west-2.amazonaws.com/{{DEPLOYMENT_BUCKET}}/dp-legacy-cache-api/{{PROFILE}}/{{RELEASE}}.tar.gz"
-      }
-
       config {
-        command = "${NOMAD_TASK_DIR}/start-task"
-
-        args = ["./dp-legacy-cache-api"]
-
-        image = "{{ECR_URL}}:concourse-{{REVISION}}"
-
-        ports = ["http"]
-      }
-
-      service {
-        name = "dp-legacy-cache-api"
-        port = "http"
-        tags = ["publishing"]
-
-        check {
-          type     = "http"
-          path     = "/health"
-          interval = "10s"
-          timeout  = "2s"
-        }
+        command = "./dp-legacy-cache-api"
+        image   = "{{ECR_URL}}:concourse-{{REVISION}}"
+        ports   = ["http"]
       }
 
       resources {
         cpu    = "{{PUBLISHING_RESOURCE_CPU}}"
         memory = "{{PUBLISHING_RESOURCE_MEM}}"
-
-        network {
-          port "http" {
-            to = 29100
-          }
-        }
       }
 
       template {
-        source      = "${NOMAD_TASK_DIR}/vars-template"
-        destination = "${NOMAD_TASK_DIR}/vars"
+        data = <<EOH
+        # Configs based on environment (e.g. export BIND_ADDR=":{{ env "NOMAD_PORT_http" }}")
+        # or static (e.g. export BIND_ADDR=":8080")
+
+        # Secret configs read from vault
+        {{ with (secret (print "secret/" (env "NOMAD_TASK_NAME"))) }}
+        {{ range $key, $value := .Data }}
+        export {{ $key }}="{{ $value }}"
+        {{ end }}
+        {{ end }}
+        EOH
+
+        destination = "secrets/app.env"
+        env         = true
+        splay       = "1m"
+        change_mode = "restart"
       }
 
       vault {

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -114,7 +114,7 @@ func TestRun(t *testing.T) {
 			Convey("The checkers are registered and the healthcheck and http server started", func() {
 				So(len(hcMock.AddCheckCalls()), ShouldEqual, 0)
 				So(len(initMock.DoGetHTTPServerCalls()), ShouldEqual, 1)
-				So(initMock.DoGetHTTPServerCalls()[0].BindAddr, ShouldEqual, "localhost:29100")
+				So(initMock.DoGetHTTPServerCalls()[0].BindAddr, ShouldEqual, ":29100")
 				So(len(hcMock.StartCalls()), ShouldEqual, 1)
 				//!!! a call needed to stop the server, maybe ?
 				serverWg.Wait() // Wait for HTTP server go-routine to finish


### PR DESCRIPTION
### What

Updated the Nomad configuration as per James' suggestion, in order to fix the API being unreachable in Sandbox. As seen in Consul, we're getting the following error:

> Get "http://10.30.140.124:22948/health": dial tcp 10.30.140.124:22948: connect: connection refused

As a result, Nomad is reporting the API as unhealthy.

### How to review

Ensure that the configuration looks right. Please notice that I have hardcoded the port in the nomad configuration. If there is a way to get it from an environment variable instead, please let me know and I'll update it.

### Who can review

Anyone.
