### PR TITLE
Create or Update Cache Time - Happy Path

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -23,9 +23,11 @@ func Setup(ctx context.Context, r *mux.Router, dataStore DataStore) *API {
 	r.HandleFunc("/mongocheck", api.AddDataSets(ctx)).Methods("POST")
 	r.HandleFunc("/mongocheck", api.GetDataSets(ctx)).Methods("GET")
 
-	// TODO: implement write endpoint here (DIS-328)
 	r.HandleFunc("/v1/cache-times/{id}", func(w http.ResponseWriter, req *http.Request) {
 		api.GetCacheTime(ctx, w, req)
 	}).Methods(http.MethodGet)
+	r.HandleFunc("/v1/cache-times/{id}", func(w http.ResponseWriter, req *http.Request) {
+		api.CreateOrUpdateCacheTime(ctx, w, req)
+	}).Methods(http.MethodPut)
 	return api
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -24,6 +24,7 @@ func TestSetup(t *testing.T) {
 			So(hasRoute(cacheAPI.Router, "/mongocheck", "POST"), ShouldBeTrue)
 			So(hasRoute(cacheAPI.Router, "/mongocheck", "GET"), ShouldBeTrue)
 			So(hasRoute(cacheAPI.Router, "/v1/cache-times/{id}", "GET"), ShouldBeTrue)
+			So(hasRoute(cacheAPI.Router, "/v1/cache-times/{id}", "PUT"), ShouldBeTrue)
 		})
 	})
 }

--- a/api/data.go
+++ b/api/data.go
@@ -68,7 +68,35 @@ func (api *API) AddDataSets(ctx context.Context) http.HandlerFunc {
 	}
 }
 
-// GetCacheTime retrieves cache time data for a given ID and writes it to the HTTP response.
+// CreateOrUpdateCacheTime handles the creation or update of a cache time
+func (api *API) CreateOrUpdateCacheTime(ctx context.Context, w http.ResponseWriter, req *http.Request) {
+	log.Info(ctx, "calling create or update cache time handler")
+
+	vars := mux.Vars(req)
+	id := vars["id"]
+
+	var docToInsertOrUpdate = &models.CacheTime{
+		ID: id,
+	}
+
+	err := json.NewDecoder(req.Body).Decode(&docToInsertOrUpdate)
+	if err != nil {
+		log.Error(ctx, "error decoding request body", err)
+		http.Error(w, "Bad Request", http.StatusBadRequest)
+		return
+	}
+
+	err = api.dataStore.UpsertCacheTime(ctx, docToInsertOrUpdate)
+	if err != nil {
+		log.Error(ctx, "error upserting document", err)
+		http.Error(w, "Internal Server Error", http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// GetCacheTime retrieves a cache time for a given ID and writes it to the HTTP response.
 func (api *API) GetCacheTime(ctx context.Context, w http.ResponseWriter, req *http.Request) {
 	log.Info(ctx, "calling get cache time handler")
 

--- a/api/data_test.go
+++ b/api/data_test.go
@@ -1,10 +1,10 @@
 package api_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -17,11 +17,12 @@ import (
 )
 
 var testCacheID = "testCacheID"
+var baseURL = "http://localhost:29100/v1/cache-times/"
+var staticTime = time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)
 
 func TestGetCacheTimeEndpoint(t *testing.T) {
 	Convey("Given a GetCacheTime handler", t, func() {
 		ctx := context.Background()
-		staticTime := time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)
 		dataStoreMock := &mock.DataStoreMock{
 			GetCacheTimeFunc: func(ctx context.Context, id string) (*models.CacheTime, error) {
 				switch id {
@@ -41,7 +42,7 @@ func TestGetCacheTimeEndpoint(t *testing.T) {
 		dataStoreAPI := setupAPIWithStore(ctx, dataStoreMock)
 
 		Convey("When an existing cache time is requested with its ID", func() {
-			request := httptest.NewRequest(http.MethodGet, fmt.Sprintf("http://localhost:29100/v1/cache-times/%s", testCacheID), http.NoBody)
+			request := httptest.NewRequest(http.MethodGet, baseURL+testCacheID, http.NoBody)
 			responseRecorder := httptest.NewRecorder()
 			dataStoreAPI.Router.ServeHTTP(responseRecorder, request)
 
@@ -59,6 +60,91 @@ func TestGetCacheTimeEndpoint(t *testing.T) {
 				So(err, ShouldBeNil)
 				So(responseRecorder.Code, ShouldEqual, http.StatusOK)
 				So(cacheTime, ShouldEqual, expectedCacheTime)
+			})
+		})
+	})
+}
+
+func TestUpdateExistingCacheTime(t *testing.T) {
+	Convey("Given an existing cache time", t, func() {
+		ctx := context.Background()
+		db := make(map[string]models.CacheTime)
+		dataStoreMock := &mock.DataStoreMock{
+			UpsertCacheTimeFunc: func(ctx context.Context, cacheTime *models.CacheTime) error {
+				db[cacheTime.ID] = *cacheTime
+				return nil
+			},
+		}
+		dataStoreAPI := setupAPIWithStore(ctx, dataStoreMock)
+
+		existingCacheTime := models.CacheTime{
+			ID:           testCacheID,
+			Path:         "existingpath",
+			ETag:         "existingetag",
+			CollectionID: 123,
+			ReleaseTime:  staticTime,
+		}
+		db[testCacheID] = existingCacheTime
+
+		Convey("When updating the cache time", func() {
+			updatedCacheTime := models.CacheTime{
+				ID:           testCacheID,
+				Path:         "updatedpath",
+				ETag:         "updatedetag",
+				CollectionID: 123,
+				ReleaseTime:  staticTime,
+			}
+			payload, err := json.Marshal(updatedCacheTime)
+			So(err, ShouldBeNil)
+			reader := bytes.NewReader(payload)
+			request := httptest.NewRequest(http.MethodPut, baseURL+testCacheID, reader)
+			responseRecorder := httptest.NewRecorder()
+			dataStoreAPI.Router.ServeHTTP(responseRecorder, request)
+
+			Convey("Then the cache time should be updated with status code 204", func() {
+				So(responseRecorder.Code, ShouldEqual, http.StatusNoContent)
+				updatedRecord, exists := db[testCacheID]
+				So(exists, ShouldBeTrue)
+				So(updatedRecord, ShouldEqual, updatedCacheTime)
+				So(responseRecorder.Body.Len(), ShouldEqual, 0)
+			})
+		})
+	})
+}
+
+func TestCreateNewCacheTime(t *testing.T) {
+	Convey("Given no existing cache time", t, func() {
+		ctx := context.Background()
+		db := make(map[string]models.CacheTime)
+		dataStoreMock := &mock.DataStoreMock{
+			UpsertCacheTimeFunc: func(ctx context.Context, cacheTime *models.CacheTime) error {
+				db[cacheTime.ID] = *cacheTime
+				return nil
+			},
+		}
+		dataStoreAPI := setupAPIWithStore(ctx, dataStoreMock)
+
+		Convey("When creating a new cache time", func() {
+			newCacheTime := models.CacheTime{
+				ID:           testCacheID,
+				Path:         "newpath",
+				ETag:         "newetag",
+				CollectionID: 123,
+				ReleaseTime:  staticTime,
+			}
+			payload, err := json.Marshal(newCacheTime)
+			So(err, ShouldBeNil)
+			reader := bytes.NewReader(payload)
+			request := httptest.NewRequest(http.MethodPut, baseURL+testCacheID, reader)
+			responseRecorder := httptest.NewRecorder()
+			dataStoreAPI.Router.ServeHTTP(responseRecorder, request)
+
+			Convey("Then a new cache time should be created with status code 204 with an empty response body", func() {
+				So(responseRecorder.Code, ShouldEqual, http.StatusNoContent)
+				createdRecord, exists := db[testCacheID]
+				So(exists, ShouldBeTrue)
+				So(createdRecord, ShouldEqual, newCacheTime)
+				So(responseRecorder.Body.Len(), ShouldEqual, 0)
 			})
 		})
 	})

--- a/api/interfaces.go
+++ b/api/interfaces.go
@@ -9,7 +9,6 @@ import (
 
 //go:generate moq -out mock/dataStore.go -pkg mock . DataStore
 //go:generate moq -out ../service/mock/store.go -pkg mock . DataStore
-//go:generate moq -out mock/bundler.go -pkg mock . DataBundler
 
 // DataStore defines the behaviour of a DataStore
 type DataStore interface {
@@ -19,4 +18,5 @@ type DataStore interface {
 	GetDataSets(ctx context.Context) ([]models.DataMessage, error)
 	AddDataSet(ctx context.Context, dataset models.DataMessage) error
 	GetCacheTime(ctx context.Context, id string) (*models.CacheTime, error)
+	UpsertCacheTime(ctx context.Context, cacheTime *models.CacheTime) error
 }

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -96,3 +96,15 @@ func (m *Mongo) GetCacheTime(ctx context.Context, id string) (*models.CacheTime,
 	}
 	return &result, nil
 }
+
+// UpsertCacheTime adds or overrides an existing cache time
+func (m *Mongo) UpsertCacheTime(ctx context.Context, cacheTime *models.CacheTime) (err error) {
+	update := bson.M{
+		"$set": cacheTime,
+	}
+	selector := bson.M{"_id": cacheTime.ID}
+
+	_, err = m.Connection.Collection(m.ActualCollectionName(config.CacheTimesCollection)).UpsertOne(ctx, selector, update)
+
+	return err
+}

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -31,7 +31,28 @@ paths:
           description: "Successfully returned a cache time for a given id"
           schema:
             $ref: "#/definitions/CacheTime"
-
+    put:
+      tags:
+        - "cache times"
+      summary: "Updates or creates a cache time"
+      description: "Updates a cache time if it exists or creates a new one for a given id"
+      consumes:
+        - "application/json"
+      parameters:
+        - in: path
+          name: id
+          description: "Unique id of cache time"
+          type: string
+          required: true
+        - in: body
+          name: body
+          description: "Cache time object that needs to be created or updated (without id)"
+          required: true
+          schema:
+            $ref: "#/definitions/CacheTimePutRequest"
+      responses:
+        204:
+          description: "Cache time successfully updated or created"
   /health:
     get:
       tags:
@@ -82,6 +103,30 @@ definitions:
         type: string
         format: date-time
         example: "2024-01-15T12:00:00Z"
+  CacheTimePutRequest:
+    type: object
+    required:
+      - path
+      - etag
+    properties:
+      path:
+        description: "Path for which caching is set"
+        type: string
+        example: "admin"
+      etag:
+        description: "ETag for cache validation"
+        type: string
+        example: "etag_example"
+      collection_id:
+        description: "Collection ID - used for grouping and filtering of cache-time objects"
+        type: integer
+        format: int32
+        example: 123
+      release_time:
+        description: "Release time in ISO-8601 format"
+        type: string
+        format: date-time
+        example: "2024-01-15T12:00:00Z"      
   CacheTimeID:
     description: "Unique identifier for CacheTime, represented as an MD5 hash of the path"
     type: string


### PR DESCRIPTION
### What

Added a new create or update cachetime handler, which will upsert a document in mongo db. This work was to implement the 204 path only. Both client and server errors will be handled as part of another ticket.

### How to review

- Ensure mongoDB container is running in docker. (run command in README.md if not)
- Run the app with `make debug`
- Attempt to insert a document that doesn't already exist. Using postman or similar, make a `PUT` request to `localhost:29100/v1/cache-times/123` with the following JSON body - `{
    "_id": "123",
    "path": "newcachetimepath",
    "etag": "newcachetimeetag",
    "collection_id": 1234,
    "release_time": "2023-12-12T00:00:00.000Z"
}`
- The response should be a 204 No Content.
- Make a `GET` request to `localhost:29100/v1/cache-times/123` - see your newly inserted cache time.
- Now attempt to update the recently inserted document by making a subsequent `PUT` request to the same URL. This time pass in the following JSON body - `{
    "_id": "123",
    "path": "updatedpath",
    "etag": "updatedetag",
    "collection_id": 1234,
    "release_time": "2023-12-12T00:00:00.000Z"
}`
- Make a `GET` request to `localhost:29100/v1/cache-times/123` - see your newly updated cache time.
### Who can review

A member of the ONS.
