### PR TITLE
Return 404 not found for cachetime read

### DIFF
--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -1,0 +1,11 @@
+package apierrors
+
+import (
+	"errors"
+)
+
+// A list of error messages for Dataset API
+var (
+	ErrCacheTimeNotFound = errors.New("cachetime not found")
+	ErrDataStore         = errors.New("DataStore error")
+)

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -96,7 +96,7 @@ func (m *Mongo) GetCacheTime(ctx context.Context, id string) (*models.CacheTime,
 			log.Info(ctx, "api.dataStore.GetCacheTime document not found")
 			return nil, errs.ErrCacheTimeNotFound
 		}
-		log.Error(ctx, "error targetting api.dataStore.GetCacheTime", err)
+		log.Error(ctx, "error targeting api.dataStore.GetCacheTime", err)
 		return nil, errs.ErrDataStore
 	}
 	return &result, nil

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -31,6 +31,10 @@ paths:
           description: "Successfully returned a cache time for a given id"
           schema:
             $ref: "#/definitions/CacheTime"
+        404:
+          description: "No cache time was found using the id provided"
+        500:
+          $ref: '#/responses/InternalError'
     put:
       tags:
         - "cache times"
@@ -94,7 +98,7 @@ definitions:
         type: string
         example: "etag_example"
       collection_id:
-        description: "Collection ID - used for grouping and filtering of cache-time objects"
+        description: "Collection ID - used for grouping and filtering of cache time objects"
         type: integer
         format: int32
         example: 123
@@ -118,7 +122,7 @@ definitions:
         type: string
         example: "etag_example"
       collection_id:
-        description: "Collection ID - used for grouping and filtering of cache-time objects"
+        description: "Collection ID - used for grouping and filtering of cache time objects"
         type: integer
         format: int32
         example: 123
@@ -128,7 +132,7 @@ definitions:
         format: date-time
         example: "2024-01-15T12:00:00Z"      
   CacheTimeID:
-    description: "Unique identifier for CacheTime, represented as an MD5 hash of the path"
+    description: "Unique identifier for a cache time, represented as an MD5 hash of the path"
     type: string
     example: "1b2b3c4d5e6f7g8h9i0j"
   Health:


### PR DESCRIPTION
### What

- 404 not found is raised when a non-existent cachetime is targeted
- Swagger documentation updated

### How to review

- Attempt to GET a cachetime with an invalid ID and the return will be a 404 not found error
- Run unit tests set-up to replicate 404 conditions and confirm all pass 

### Who can review

Anyone from ONS
