### PR TITLE
Increase the linter timeout

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,7 +5,7 @@ run:
   concurrency: 4
 
   # timeout for analysis, e.g. 30s, 5m, default is 1m
-  timeout: 5m
+  timeout: 10m
 linters-settings:
   govet:
     check-shadowing: true


### PR DESCRIPTION
### What

The linter timeout has been increased, as we've noticed intermittent failures in the pipeline before due to this.

### How to review

Ensure that the new configuration makes sense, and that the linter does not fail in the pipeline anymore.

### Who can review

Anyone.
