### PR TITLE
Added IsPublishing bool feature flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,36 +1,39 @@
 # dp-legacy-cache-api
+
 REST API for managing cache control information for pages within the legacy CMS
 
 ### Getting started
-* Ensure Docker is installed on your local machine, installation steps can be found here https://docs.docker.com/desktop/install/mac-install/
-* Run `docker run --name mongo-test -p 27017:27017 -e MONGO_INITDB_DATABASE=cache -v $(pwd)/mongo-init:/docker-entrypoint-initdb.d -d mongo`. This command launches a MongoDB container named mongo-test, maps port 27017 from the host to the container, sets cache as the default database, runs initialization scripts from a host directory, and operates in the background.
-* Run `make debug` to run application on http://localhost:29100
-* Run `make help` to see full list of make targets
+
+- Ensure Docker is installed on your local machine, installation steps can be found here https://docs.docker.com/desktop/install/mac-install/
+- Run `docker run --name mongo-test -p 27017:27017 -e MONGO_INITDB_DATABASE=cache -v $(pwd)/mongo-init:/docker-entrypoint-initdb.d -d mongo`. This command launches a MongoDB container named mongo-test, maps port 27017 from the host to the container, sets cache as the default database, runs initialization scripts from a host directory, and operates in the background.
+- Run `make debug` to run application on http://localhost:29100
+- Run `make help` to see full list of make targets
 
 ### Dependencies
 
-* No further dependencies other than those defined in `go.mod`
+- No further dependencies other than those defined in `go.mod`
 
 ### Configuration
 
-| Environment variable               | Default                                                    | Description                                                                                                         |
-|------------------------------------|------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------|                
-| BIND_ADDR                          | :29100                                                     | The host and port to bind to                                                                                        |
-| MONGODB_BIND_ADDR                  | localhost:27017                                            | The MongoDB bind address                                                                                            |
-| MONGODB_USERNAME                   |                                                            | The MongoDB Username                                                                                                |
-| MONGODB_PASSWORD                   |                                                            | The MongoDB Password                                                                                                |
-| MONGODB_DATABASE                   | cache                                                      | The MongoDB database                                                                                                |
-| MONGODB_COLLECTIONS                | CacheTimesCollection:cachetimes                            | The MongoDB collections                                                                                             |                           
-| MONGODB_REPLICA_SET                |                                                            | The name of the MongoDB replica set                                                                                 |
-| MONGODB_ENABLE_READ_CONCERN        | false                                                      | Switch to use (or not) majority read concern                                                                        |
-| MONGODB_ENABLE_WRITE_CONCERN       | true                                                       | Switch to use (or not) majority write concern                                                                       |
-| MONGODB_CONNECT_TIMEOUT            | 5s                                                         | The timeout when connecting to MongoDB (`time.Duration` format)                                                     |
-| MONGODB_QUERY_TIMEOUT              | 15s                                                        | The timeout for querying MongoDB (`time.Duration` format)                                                           |
-| MONGODB_IS_SSL                     | false                                                      | Switch to use (or not) TLS when connecting to mongodb                                                               |
-| GRACEFUL_SHUTDOWN_TIMEOUT          | 5s                                                         | The graceful shutdown timeout in seconds (`time.Duration` format)                                                   |
-| HEALTHCHECK_INTERVAL               | 30s                                                        | Time between self-healthchecks (`time.Duration` format)                                                             |
-| HEALTHCHECK_CRITICAL_TIMEOUT       | 90s                                                        | Time to wait until an unhealthy dependent propagates its
+| Environment variable         | Default                         | Description                                                                                                        |
+| ---------------------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| BIND_ADDR                    | :29100                          | The host and port to bind to                                                                                       |
+| MONGODB_BIND_ADDR            | localhost:27017                 | The MongoDB bind address                                                                                           |
+| MONGODB_USERNAME             |                                 | The MongoDB Username                                                                                               |
+| MONGODB_PASSWORD             |                                 | The MongoDB Password                                                                                               |
+| MONGODB_DATABASE             | cache                           | The MongoDB database                                                                                               |
+| MONGODB_COLLECTIONS          | CacheTimesCollection:cachetimes | The MongoDB collections                                                                                            |
+| MONGODB_REPLICA_SET          |                                 | The name of the MongoDB replica set                                                                                |
+| MONGODB_ENABLE_READ_CONCERN  | false                           | Switch to use (or not) majority read concern                                                                       |
+| MONGODB_ENABLE_WRITE_CONCERN | true                            | Switch to use (or not) majority write concern                                                                      |
+| MONGODB_CONNECT_TIMEOUT      | 5s                              | The timeout when connecting to MongoDB (`time.Duration` format)                                                    |
+| MONGODB_QUERY_TIMEOUT        | 15s                             | The timeout for querying MongoDB (`time.Duration` format)                                                          |
+| MONGODB_IS_SSL               | false                           | Switch to use (or not) TLS when connecting to mongodb                                                              |
+| GRACEFUL_SHUTDOWN_TIMEOUT    | 5s                              | The graceful shutdown timeout in seconds (`time.Duration` format)                                                  |
+| HEALTHCHECK_INTERVAL         | 30s                             | Time between self-healthchecks (`time.Duration` format)                                                            |
+| HEALTHCHECK_CRITICAL_TIMEOUT | 90s                             | Time to wait until an unhealthy dependent propagates its state to make this app unhealthy (`time.Duration` format) |
+| IS_PUBLISHING                | false                           | Determines if the instance is in publishing or not                                                                 |
 
-Copyright © 2023, Office for National Statistics (https://www.ons.gov.uk)
+Copyright © 2024, Office for National Statistics (https://www.ons.gov.uk)
 
 Released under MIT license, see [LICENSE](LICENSE.md) for details.

--- a/api/api.go
+++ b/api/api.go
@@ -14,7 +14,7 @@ type API struct {
 }
 
 // Setup function sets up the api and returns an api
-func Setup(ctx context.Context, r *mux.Router, dataStore DataStore) *API {
+func Setup(ctx context.Context, isPublishing bool, r *mux.Router, dataStore DataStore) *API {
 	api := &API{
 		Router:    r,
 		dataStore: dataStore,
@@ -23,8 +23,11 @@ func Setup(ctx context.Context, r *mux.Router, dataStore DataStore) *API {
 	r.HandleFunc("/v1/cache-times/{id}", func(w http.ResponseWriter, req *http.Request) {
 		api.GetCacheTime(ctx, w, req)
 	}).Methods(http.MethodGet)
-	r.HandleFunc("/v1/cache-times/{id}", func(w http.ResponseWriter, req *http.Request) {
-		api.CreateOrUpdateCacheTime(ctx, w, req)
-	}).Methods(http.MethodPut)
+
+	if isPublishing {
+		r.HandleFunc("/v1/cache-times/{id}", func(w http.ResponseWriter, req *http.Request) {
+			api.CreateOrUpdateCacheTime(ctx, w, req)
+		}).Methods(http.MethodPut)
+	}
 	return api
 }

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -18,11 +18,23 @@ func TestSetup(t *testing.T) {
 		ctx := context.Background()
 
 		mockMongoDB := &mock.DataStoreMock{}
-		cacheAPI := api.Setup(ctx, router, mockMongoDB)
+		Convey("When created in publishing subnet", func() {
+			var isPublishing = true
+			cacheAPI := api.Setup(ctx, isPublishing, router, mockMongoDB)
 
-		Convey("When created the following routes should have been added", func() {
-			So(hasRoute(cacheAPI.Router, "/v1/cache-times/{id}", "GET"), ShouldBeTrue)
-			So(hasRoute(cacheAPI.Router, "/v1/cache-times/{id}", "PUT"), ShouldBeTrue)
+			Convey("Then all the routes should be available", func() {
+				So(hasRoute(cacheAPI.Router, "/v1/cache-times/{id}", "GET"), ShouldBeTrue)
+				So(hasRoute(cacheAPI.Router, "/v1/cache-times/{id}", "PUT"), ShouldBeTrue)
+			})
+		})
+		Convey("When created in web subnet", func() {
+			var isPublishing = false
+			cacheAPI := api.Setup(ctx, isPublishing, router, mockMongoDB)
+
+			Convey("Then the PUT endpoint should not have been added", func() {
+				So(hasRoute(cacheAPI.Router, "/v1/cache-times/{id}", "GET"), ShouldBeTrue)
+				So(hasRoute(cacheAPI.Router, "/v1/cache-times/{id}", "PUT"), ShouldBeFalse)
+			})
 		})
 	})
 }
@@ -33,6 +45,6 @@ func hasRoute(r *mux.Router, path, method string) bool {
 	return r.Match(req, match)
 }
 
-func setupAPIWithStore(ctx context.Context, dataStore api.DataStore) *api.API {
-	return api.Setup(ctx, mux.NewRouter(), dataStore)
+func setupAPIWithStore(ctx context.Context, isPublishing bool, dataStore api.DataStore) *api.API {
+	return api.Setup(ctx, isPublishing, mux.NewRouter(), dataStore)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	GracefulShutdownTimeout    time.Duration `envconfig:"GRACEFUL_SHUTDOWN_TIMEOUT"`
 	HealthCheckInterval        time.Duration `envconfig:"HEALTHCHECK_INTERVAL"`
 	HealthCheckCriticalTimeout time.Duration `envconfig:"HEALTHCHECK_CRITICAL_TIMEOUT"`
+	IsPublishing               bool          `envconfig:"IS_PUBLISHING"`
 	MongoConfig
 }
 
@@ -34,6 +35,7 @@ func Get() (*Config, error) {
 		GracefulShutdownTimeout:    5 * time.Second,
 		HealthCheckInterval:        30 * time.Second,
 		HealthCheckCriticalTimeout: 90 * time.Second,
+		IsPublishing:               false,
 		MongoConfig: MongoConfig{
 			ClusterEndpoint:               "localhost:27017",
 			Username:                      "",

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -28,6 +28,7 @@ func TestConfig(t *testing.T) {
 					GracefulShutdownTimeout:    5 * time.Second,
 					HealthCheckInterval:        30 * time.Second,
 					HealthCheckCriticalTimeout: 90 * time.Second,
+					IsPublishing:               false,
 					MongoConfig: mongodriver.MongoDriverConfig{
 						ClusterEndpoint:               "localhost:27017",
 						Username:                      "",

--- a/features/steps/api_component.go
+++ b/features/steps/api_component.go
@@ -40,6 +40,7 @@ func NewComponent(mongoURI, mongoDatabaseName string) (*Component, error) {
 		return nil, err
 	}
 
+	c.Config.IsPublishing = true
 	c.Config.MongoConfig.ClusterEndpoint = mongoURI
 	c.Config.MongoConfig.Database = mongoDatabaseName
 

--- a/service/service.go
+++ b/service/service.go
@@ -40,7 +40,7 @@ func Run(ctx context.Context, cfg *config.Config, serviceList *ExternalServiceLi
 	}
 
 	// Setup the API
-	cacheAPI := api.Setup(ctx, router, mongoDB)
+	cacheAPI := api.Setup(ctx, cfg.IsPublishing, router, mongoDB)
 
 	hc, err := serviceList.GetHealthCheck(cfg, buildTime, gitCommit, version)
 	if err != nil {


### PR DESCRIPTION
### What

Added a new env var `IsPublishing` to only allow publishing mode access to PUT endpoint.

### How to review

1. Run App, Make valid `PUT` request via ThunderClient or similar, confirm endpoint works as expected.
2. Change `IsPublishing` var inside `config.go` to false. 
3. Run component tests `make test-component` (PUT endpoint tests should fail). Please note: the config test will now fail too - but thats fine.
4. Make valid PUT request as above, `405 Method Not Allowed` should be returned.

### Who can review

A member of the ONS.
