### PR TITLE
add service token to auth request & fake auth zebedee in component test

### DIFF
--- a/features/steps/api_component.go
+++ b/features/steps/api_component.go
@@ -26,7 +26,7 @@ type Component struct {
 	MongoClient    *mongo.Mongo
 }
 
-func NewComponent(mongoURI, mongoDatabaseName string) (*Component, error) {
+func NewComponent(mongoURI, mongoDatabaseName, zebedeeURL string) (*Component, error) {
 	c := &Component{
 		HTTPServer:     &http.Server{ReadHeaderTimeout: 3 * time.Second},
 		errorChan:      make(chan error),
@@ -43,6 +43,7 @@ func NewComponent(mongoURI, mongoDatabaseName string) (*Component, error) {
 	c.Config.IsPublishing = true
 	c.Config.MongoConfig.ClusterEndpoint = mongoURI
 	c.Config.MongoConfig.Database = mongoDatabaseName
+	c.Config.ZebedeeURL = zebedeeURL
 
 	c.MongoClient, err = mongo.NewMongoStore(context.Background(), c.Config.MongoConfig)
 	if err != nil {

--- a/features/upsert.feature
+++ b/features/upsert.feature
@@ -2,6 +2,7 @@ Feature: Upsert Cache Time
 
   Scenario: Create Cache Time resource
     Given the document with "_id" set to "5d41402abc4b2a76b9719d911017c592" does not exist in the "cachetimes" collection
+    And I am authorised
     When I PUT "/v1/cache-times/5d41402abc4b2a76b9719d911017c592"
             """
             {
@@ -24,6 +25,7 @@ Feature: Upsert Cache Time
                 "release_time": "2024-01-31T01:23:45.678Z"
             }
             """
+    And I am authorised
     When I PUT "/v1/cache-times/5d41402abc4b2a76b9719d911017c592"
             """
             {
@@ -37,6 +39,7 @@ Feature: Upsert Cache Time
 
   Scenario: Upsert Cache Time resource with empty body
     Given the document with "_id" set to "5d41402abc4b2a76b9719d911017c592" does not exist in the "cachetimes" collection
+    And I am authorised
     When I PUT "/v1/cache-times/5d41402abc4b2a76b9719d911017c592"
             """
             """
@@ -44,6 +47,7 @@ Feature: Upsert Cache Time
 
   Scenario: Upsert Cache Time resource with empty release_time & collection_id
     Given the document with "_id" set to "5d41402abc4b2a76b9719d911017c592" does not exist in the "cachetimes" collection
+    And I am authorised
     When I PUT "/v1/cache-times/5d41402abc4b2a76b9719d911017c592"
             """
             {
@@ -73,6 +77,7 @@ Feature: Upsert Cache Time
                 "release_time": "2024-01-31T01:23:45.678Z"
             }
             """
+    And I am authorised
     When I PUT "/v1/cache-times/5d41402abc4b2a76b9719d911017c592"
             """
             {


### PR DESCRIPTION
fix component test by adding stubbed zebedee responses

also needed service auth token added to request (zebedee client)


assumes that you'll be adding a service auth token for this service at some point, or are passing one along