### PR TITLE
Remove reference to etags

### DIFF
--- a/api/data.go
+++ b/api/data.go
@@ -99,9 +99,6 @@ func (api *API) GetCacheTime(ctx context.Context, w http.ResponseWriter, req *ht
 func isValidCacheTime(cacheTime *models.CacheTime) error {
 	e := findIDErrors(cacheTime.ID)
 
-	if cacheTime.ETag == "" {
-		e = append(e, errors.New("etag field missing"))
-	}
 	if cacheTime.Path == "" {
 		e = append(e, errors.New("path field missing"))
 	}

--- a/api/data_test.go
+++ b/api/data_test.go
@@ -18,7 +18,7 @@ import (
 	. "github.com/smartystreets/goconvey/convey"
 )
 
-var validBody = `{"path": "testpath", "etag": "testetag"}`
+var validBody = `{"path": "testpath"}`
 var testCacheID = "a1b2c3d4e5f67890123456789abcdef0"
 var baseURL = "http://localhost:29100/v1/cache-times/"
 var staticTime = time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)
@@ -33,7 +33,6 @@ func TestGetCacheTimeEndpoint(t *testing.T) {
 					return &models.CacheTime{
 						ID:           testCacheID,
 						Path:         "testpath",
-						ETag:         "testetag",
 						CollectionID: 123,
 						ReleaseTime:  staticTimePtr,
 					}, nil
@@ -53,7 +52,6 @@ func TestGetCacheTimeEndpoint(t *testing.T) {
 				expectedCacheTime := models.CacheTime{
 					ID:           testCacheID,
 					Path:         "testpath",
-					ETag:         "testetag",
 					CollectionID: 123,
 					ReleaseTime:  staticTimePtr,
 				}
@@ -125,7 +123,6 @@ func TestUpdateExistingCacheTime(t *testing.T) {
 		existingCacheTime := models.CacheTime{
 			ID:           testCacheID,
 			Path:         "existingpath",
-			ETag:         "existingetag",
 			CollectionID: 123,
 			ReleaseTime:  staticTimePtr,
 		}
@@ -135,7 +132,6 @@ func TestUpdateExistingCacheTime(t *testing.T) {
 			updatedCacheTime := models.CacheTime{
 				ID:           testCacheID,
 				Path:         "updatedpath",
-				ETag:         "updatedetag",
 				CollectionID: 123,
 				ReleaseTime:  staticTimePtr,
 			}
@@ -172,7 +168,6 @@ func TestCreateNewCacheTime(t *testing.T) {
 			newCacheTime := models.CacheTime{
 				ID:           testCacheID,
 				Path:         "newpath",
-				ETag:         "newetag",
 				CollectionID: 123,
 				ReleaseTime:  staticTimePtr,
 			}
@@ -201,7 +196,6 @@ func TestCreateNewCacheTime(t *testing.T) {
 				expectedCacheTime := models.CacheTime{
 					ID:           testCacheID,
 					Path:         "testpath",
-					ETag:         "testetag",
 					CollectionID: 0,
 					ReleaseTime:  nil,
 				}
@@ -252,7 +246,7 @@ func TestCreateOrUpdateCacheTimeReturnsErr(t *testing.T) {
 			})
 		})
 
-		Convey("When an etag and/or path is not provided and the CreateOrUpdateCacheTime endpoint is called", func() {
+		Convey("When path is not provided and the CreateOrUpdateCacheTime endpoint is called", func() {
 			staticTimeString := staticTime.Format(time.RFC3339)
 			body := `{"collection_id": 123, "release_time":"` + staticTimeString + `"}`
 			request := newRequestWithAuth(http.MethodPut, baseURL+testCacheID, bytes.NewBufferString(body))
@@ -261,12 +255,12 @@ func TestCreateOrUpdateCacheTimeReturnsErr(t *testing.T) {
 
 			Convey("Then a 400 is returned with the missing fields in the response", func() {
 				So(responseRecorder.Code, ShouldEqual, http.StatusBadRequest)
-				So(responseRecorder.Body.String(), ShouldContainSubstring, "[etag field missing, path field missing]")
+				So(responseRecorder.Body.String(), ShouldContainSubstring, "[path field missing]")
 			})
 		})
 
 		Convey("When an extra field is provided and the CreateOrUpdateCacheTime endpoint is called", func() {
-			body := `{"path": "testpath", "etag": "testetag", "extra_field": "hello" }`
+			body := `{"path": "testpath", "extra_field": "hello" }`
 			request := newRequestWithAuth(http.MethodPut, baseURL+testCacheID, bytes.NewBufferString(body))
 			responseRecorder := httptest.NewRecorder()
 			dataStoreAPI.Router.ServeHTTP(responseRecorder, request)
@@ -278,7 +272,7 @@ func TestCreateOrUpdateCacheTimeReturnsErr(t *testing.T) {
 		})
 
 		Convey("When the field type provided is not the expected and the CreateOrUpdateCacheTime endpoint is called", func() {
-			body := `{"path": 1234, "etag": "testetag"}`
+			body := `{"path": 1234}`
 			request := newRequestWithAuth(http.MethodPut, baseURL+testCacheID, bytes.NewBufferString(body))
 			responseRecorder := httptest.NewRecorder()
 			dataStoreAPI.Router.ServeHTTP(responseRecorder, request)

--- a/features/read.feature
+++ b/features/read.feature
@@ -6,7 +6,6 @@ Feature: Read Cache Time
       {
         "_id": "5d41402abc4b2a76b9719d911017c592",
         "path": "/my-path",
-        "etag": "test-etag",
         "collection_id": 123456,
         "release_time": "2024-01-31T01:23:45.678Z"
       }
@@ -17,7 +16,6 @@ Feature: Read Cache Time
       {
         "_id": "5d41402abc4b2a76b9719d911017c592",
         "path": "/my-path",
-        "etag": "test-etag",
         "collection_id": 123456,
         "release_time": "2024-01-31T01:23:45.678Z"
       }

--- a/features/upsert.feature
+++ b/features/upsert.feature
@@ -7,7 +7,6 @@ Feature: Upsert Cache Time
       """
       {
         "path": "/my-path",
-        "etag": "test-etag",
         "collection_id": 123456,
         "release_time": "2024-01-31T01:23:45.678Z"
       }
@@ -20,7 +19,6 @@ Feature: Upsert Cache Time
       {
         "_id": "5d41402abc4b2a76b9719d911017c592",
         "path": "/my-path",
-        "etag": "test-etag",
         "collection_id": 123456,
         "release_time": "2024-01-31T01:23:45.678Z"
       }
@@ -30,7 +28,6 @@ Feature: Upsert Cache Time
       """
       {
         "path": "/some/other/path",
-        "etag": "a-different-etag",
         "collection_id": 999,
         "release_time": "1999-12-23T11:22:33.444Z"
       }
@@ -51,8 +48,7 @@ Feature: Upsert Cache Time
     When I PUT "/v1/cache-times/5d41402abc4b2a76b9719d911017c592"
       """
       {
-        "path": "/my-path",
-        "etag": "test-etag"
+        "path": "/my-path"
       }
       """
     Then the HTTP status code should be "204"
@@ -61,8 +57,7 @@ Feature: Upsert Cache Time
       """
       {
         "_id": "5d41402abc4b2a76b9719d911017c592",
-        "path": "/my-path",
-        "etag": "test-etag"
+        "path": "/my-path"
       }
       """
 
@@ -72,7 +67,6 @@ Feature: Upsert Cache Time
       {
         "_id": "5d41402abc4b2a76b9719d911017c592",
         "path": "/my-path",
-        "etag": "test-etag",
         "collection_id": 123456,
         "release_time": "2024-01-31T01:23:45.678Z"
       }
@@ -81,8 +75,7 @@ Feature: Upsert Cache Time
     When I PUT "/v1/cache-times/5d41402abc4b2a76b9719d911017c592"
       """
       {
-        "path": "/some/other/path",
-        "etag": "a-different-etag"
+        "path": "/some/other/path"
       }
       """
     Then the HTTP status code should be "204"
@@ -91,8 +84,7 @@ Feature: Upsert Cache Time
       """
       {
         "_id": "5d41402abc4b2a76b9719d911017c592",
-        "path": "/some/other/path",
-        "etag": "a-different-etag"
+        "path": "/some/other/path"
       }
       """
 
@@ -102,7 +94,6 @@ Feature: Upsert Cache Time
       """
       {
         "path": "/my-path",
-        "etag": "test-etag",
         "collection_id": 123456,
         "release_time": "2024-01-31T01:23:45.678Z"
       }

--- a/models/cachetime.go
+++ b/models/cachetime.go
@@ -5,7 +5,6 @@ import "time"
 type CacheTime struct {
 	ID           string     `bson:"_id" json:"_id"`                                         // MD5 of the path
 	Path         string     `bson:"path" json:"path"`                                       // Path for which caching is set
-	ETag         string     `bson:"etag" json:"etag"`                                       // ETag for cache validation
 	CollectionID int        `bson:"collection_id,omitempty" json:"collection_id,omitempty"` // Collection ID - used for grouping and filtering of cache-time objects.
 	ReleaseTime  *time.Time `bson:"release_time,omitempty" json:"release_time,omitempty"`   // Release time in ISO-8601 format
 }

--- a/mongo/mongo.go
+++ b/mongo/mongo.go
@@ -81,7 +81,7 @@ func (m *Mongo) GetCacheTime(ctx context.Context, id string) (*models.CacheTime,
 // UpsertCacheTime adds or overrides an existing cache time
 func (m *Mongo) UpsertCacheTime(ctx context.Context, cacheTime *models.CacheTime) (err error) {
 	update := bson.M{
-		"$set": bson.M{"path": cacheTime.Path, "etag": cacheTime.ETag, "collection_id": cacheTime.CollectionID, "release_time": cacheTime.ReleaseTime},
+		"$set": bson.M{"path": cacheTime.Path, "collection_id": cacheTime.CollectionID, "release_time": cacheTime.ReleaseTime},
 	}
 	selector := bson.M{"_id": cacheTime.ID}
 

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -95,7 +95,6 @@ definitions:
     required:
       - id
       - path
-      - etag
     properties:
       id:
         $ref: "#/definitions/CacheTimeID"
@@ -103,10 +102,6 @@ definitions:
         description: "Path for which caching is set"
         type: string
         example: "admin"
-      etag:
-        description: "ETag for cache validation"
-        type: string
-        example: "etag_example"
       collection_id:
         description: "Collection ID - used for grouping and filtering of cache time objects"
         type: integer
@@ -121,16 +116,11 @@ definitions:
     type: object
     required:
       - path
-      - etag
     properties:
       path:
         description: "Path for which caching is set"
         type: string
         example: "admin"
-      etag:
-        description: "ETag for cache validation"
-        type: string
-        example: "etag_example"
       collection_id:
         description: "Collection ID - used for grouping and filtering of cache time objects"
         type: integer


### PR DESCRIPTION
### What

Removed reference to etags across the repo, since they are not used in the api

### How to review

Checkout the changes, ensuring that there are no references to etags and that the tests still run

### Who can review

Anyone
