### PR TITLE
Replace instances of collectionID integer field with string

### DIFF
--- a/api/data_test.go
+++ b/api/data_test.go
@@ -33,7 +33,7 @@ func TestGetCacheTimeEndpoint(t *testing.T) {
 					return &models.CacheTime{
 						ID:           testCacheID,
 						Path:         "testpath",
-						CollectionID: 123,
+						CollectionID: "123",
 						ReleaseTime:  staticTimePtr,
 					}, nil
 				default:
@@ -52,7 +52,7 @@ func TestGetCacheTimeEndpoint(t *testing.T) {
 				expectedCacheTime := models.CacheTime{
 					ID:           testCacheID,
 					Path:         "testpath",
-					CollectionID: 123,
+					CollectionID: "123",
 					ReleaseTime:  staticTimePtr,
 				}
 				cacheTime := models.CacheTime{}
@@ -123,7 +123,7 @@ func TestUpdateExistingCacheTime(t *testing.T) {
 		existingCacheTime := models.CacheTime{
 			ID:           testCacheID,
 			Path:         "existingpath",
-			CollectionID: 123,
+			CollectionID: "123",
 			ReleaseTime:  staticTimePtr,
 		}
 		db[testCacheID] = existingCacheTime
@@ -132,7 +132,7 @@ func TestUpdateExistingCacheTime(t *testing.T) {
 			updatedCacheTime := models.CacheTime{
 				ID:           testCacheID,
 				Path:         "updatedpath",
-				CollectionID: 123,
+				CollectionID: "123",
 				ReleaseTime:  staticTimePtr,
 			}
 			payload, err := json.Marshal(updatedCacheTime)
@@ -168,7 +168,7 @@ func TestCreateNewCacheTime(t *testing.T) {
 			newCacheTime := models.CacheTime{
 				ID:           testCacheID,
 				Path:         "newpath",
-				CollectionID: 123,
+				CollectionID: "123",
 				ReleaseTime:  staticTimePtr,
 			}
 			payload, err := json.Marshal(newCacheTime)
@@ -196,7 +196,7 @@ func TestCreateNewCacheTime(t *testing.T) {
 				expectedCacheTime := models.CacheTime{
 					ID:           testCacheID,
 					Path:         "testpath",
-					CollectionID: 0,
+					CollectionID: "",
 					ReleaseTime:  nil,
 				}
 				So(responseRecorder.Code, ShouldEqual, http.StatusNoContent)
@@ -248,7 +248,7 @@ func TestCreateOrUpdateCacheTimeReturnsErr(t *testing.T) {
 
 		Convey("When path is not provided and the CreateOrUpdateCacheTime endpoint is called", func() {
 			staticTimeString := staticTime.Format(time.RFC3339)
-			body := `{"collection_id": 123, "release_time":"` + staticTimeString + `"}`
+			body := `{"collection_id": "123", "release_time":"` + staticTimeString + `"}`
 			request := newRequestWithAuth(http.MethodPut, baseURL+testCacheID, bytes.NewBufferString(body))
 			responseRecorder := httptest.NewRecorder()
 			dataStoreAPI.Router.ServeHTTP(responseRecorder, request)

--- a/api/data_test.go
+++ b/api/data_test.go
@@ -23,6 +23,7 @@ var testCacheID = "a1b2c3d4e5f67890123456789abcdef0"
 var baseURL = "http://localhost:29100/v1/cache-times/"
 var staticTime = time.Date(2024, time.January, 1, 0, 0, 0, 0, time.UTC)
 var staticTimePtr = &staticTime
+var testCollectionID = "test-1a19e3462937d85804752375daa00ba41d1b6625d396f21000e3c4571ebf2606"
 
 func TestGetCacheTimeEndpoint(t *testing.T) {
 	Convey("Given a GetCacheTime handler", t, func() {
@@ -33,7 +34,7 @@ func TestGetCacheTimeEndpoint(t *testing.T) {
 					return &models.CacheTime{
 						ID:           testCacheID,
 						Path:         "testpath",
-						CollectionID: "123",
+						CollectionID: testCollectionID,
 						ReleaseTime:  staticTimePtr,
 					}, nil
 				default:
@@ -52,7 +53,7 @@ func TestGetCacheTimeEndpoint(t *testing.T) {
 				expectedCacheTime := models.CacheTime{
 					ID:           testCacheID,
 					Path:         "testpath",
-					CollectionID: "123",
+					CollectionID: testCollectionID,
 					ReleaseTime:  staticTimePtr,
 				}
 				cacheTime := models.CacheTime{}
@@ -123,7 +124,7 @@ func TestUpdateExistingCacheTime(t *testing.T) {
 		existingCacheTime := models.CacheTime{
 			ID:           testCacheID,
 			Path:         "existingpath",
-			CollectionID: "123",
+			CollectionID: testCollectionID,
 			ReleaseTime:  staticTimePtr,
 		}
 		db[testCacheID] = existingCacheTime
@@ -132,7 +133,7 @@ func TestUpdateExistingCacheTime(t *testing.T) {
 			updatedCacheTime := models.CacheTime{
 				ID:           testCacheID,
 				Path:         "updatedpath",
-				CollectionID: "123",
+				CollectionID: testCollectionID,
 				ReleaseTime:  staticTimePtr,
 			}
 			payload, err := json.Marshal(updatedCacheTime)
@@ -168,7 +169,7 @@ func TestCreateNewCacheTime(t *testing.T) {
 			newCacheTime := models.CacheTime{
 				ID:           testCacheID,
 				Path:         "newpath",
-				CollectionID: "123",
+				CollectionID: testCollectionID,
 				ReleaseTime:  staticTimePtr,
 			}
 			payload, err := json.Marshal(newCacheTime)
@@ -248,7 +249,7 @@ func TestCreateOrUpdateCacheTimeReturnsErr(t *testing.T) {
 
 		Convey("When path is not provided and the CreateOrUpdateCacheTime endpoint is called", func() {
 			staticTimeString := staticTime.Format(time.RFC3339)
-			body := `{"collection_id": "123", "release_time":"` + staticTimeString + `"}`
+			body := `{"collection_id":"` + testCollectionID + `", "release_time":"` + staticTimeString + `"}`
 			request := newRequestWithAuth(http.MethodPut, baseURL+testCacheID, bytes.NewBufferString(body))
 			responseRecorder := httptest.NewRecorder()
 			dataStoreAPI.Router.ServeHTTP(responseRecorder, request)

--- a/features/read.feature
+++ b/features/read.feature
@@ -6,7 +6,7 @@ Feature: Read Cache Time
       {
         "_id": "5d41402abc4b2a76b9719d911017c592",
         "path": "/my-path",
-        "collection_id": 123456,
+        "collection_id": "123456",
         "release_time": "2024-01-31T01:23:45.678Z"
       }
       """
@@ -16,7 +16,7 @@ Feature: Read Cache Time
       {
         "_id": "5d41402abc4b2a76b9719d911017c592",
         "path": "/my-path",
-        "collection_id": 123456,
+        "collection_id": "123456",
         "release_time": "2024-01-31T01:23:45.678Z"
       }
       """

--- a/features/read.feature
+++ b/features/read.feature
@@ -6,7 +6,7 @@ Feature: Read Cache Time
       {
         "_id": "5d41402abc4b2a76b9719d911017c592",
         "path": "/my-path",
-        "collection_id": "123456",
+        "collection_id": "test-1a19e3462937d85804752375daa00ba41d1b6625d396f21000e3c4571ebf2606",
         "release_time": "2024-01-31T01:23:45.678Z"
       }
       """
@@ -16,7 +16,7 @@ Feature: Read Cache Time
       {
         "_id": "5d41402abc4b2a76b9719d911017c592",
         "path": "/my-path",
-        "collection_id": "123456",
+        "collection_id": "test-1a19e3462937d85804752375daa00ba41d1b6625d396f21000e3c4571ebf2606",
         "release_time": "2024-01-31T01:23:45.678Z"
       }
       """

--- a/features/upsert.feature
+++ b/features/upsert.feature
@@ -7,7 +7,7 @@ Feature: Upsert Cache Time
       """
       {
         "path": "/my-path",
-        "collection_id": 123456,
+        "collection_id": "123456",
         "release_time": "2024-01-31T01:23:45.678Z"
       }
       """
@@ -19,7 +19,7 @@ Feature: Upsert Cache Time
       {
         "_id": "5d41402abc4b2a76b9719d911017c592",
         "path": "/my-path",
-        "collection_id": 123456,
+        "collection_id": "123456",
         "release_time": "2024-01-31T01:23:45.678Z"
       }
       """
@@ -28,7 +28,7 @@ Feature: Upsert Cache Time
       """
       {
         "path": "/some/other/path",
-        "collection_id": 999,
+        "collection_id": "999",
         "release_time": "1999-12-23T11:22:33.444Z"
       }
       """

--- a/features/upsert.feature
+++ b/features/upsert.feature
@@ -7,7 +7,7 @@ Feature: Upsert Cache Time
       """
       {
         "path": "/my-path",
-        "collection_id": "123456",
+        "collection_id": "test-1a19e3462937d85804752375daa00ba41d1b6625d396f21000e3c4571ebf2606",
         "release_time": "2024-01-31T01:23:45.678Z"
       }
       """
@@ -19,7 +19,7 @@ Feature: Upsert Cache Time
       {
         "_id": "5d41402abc4b2a76b9719d911017c592",
         "path": "/my-path",
-        "collection_id": "123456",
+        "collection_id": "test-1a19e3462937d85804752375daa00ba41d1b6625d396f21000e3c4571ebf2606",
         "release_time": "2024-01-31T01:23:45.678Z"
       }
       """
@@ -28,7 +28,7 @@ Feature: Upsert Cache Time
       """
       {
         "path": "/some/other/path",
-        "collection_id": "999",
+        "collection_id": "updatedcollectionid-aa00ba41d1b6625d396f21000e3c4571ebf26061a19e3462937d85804752375d",
         "release_time": "1999-12-23T11:22:33.444Z"
       }
       """
@@ -67,7 +67,7 @@ Feature: Upsert Cache Time
       {
         "_id": "5d41402abc4b2a76b9719d911017c592",
         "path": "/my-path",
-        "collection_id": 123456,
+        "collection_id": "test-1a19e3462937d85804752375daa00ba41d1b6625d396f21000e3c4571ebf2606",
         "release_time": "2024-01-31T01:23:45.678Z"
       }
       """
@@ -94,7 +94,7 @@ Feature: Upsert Cache Time
       """
       {
         "path": "/my-path",
-        "collection_id": 123456,
+        "collection_id": "test-1a19e3462937d85804752375daa00ba41d1b6625d396f21000e3c4571ebf2606",
         "release_time": "2024-01-31T01:23:45.678Z"
       }
       """

--- a/models/cachetime.go
+++ b/models/cachetime.go
@@ -5,6 +5,6 @@ import "time"
 type CacheTime struct {
 	ID           string     `bson:"_id" json:"_id"`                                         // MD5 of the path
 	Path         string     `bson:"path" json:"path"`                                       // Path for which caching is set
-	CollectionID int        `bson:"collection_id,omitempty" json:"collection_id,omitempty"` // Collection ID - used for grouping and filtering of cache-time objects.
+	CollectionID string     `bson:"collection_id,omitempty" json:"collection_id,omitempty"` // Collection ID - used for grouping and filtering of cache-time objects.
 	ReleaseTime  *time.Time `bson:"release_time,omitempty" json:"release_time,omitempty"`   // Release time in ISO-8601 format
 }

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -104,9 +104,8 @@ definitions:
         example: "admin"
       collection_id:
         description: "Collection ID - used for grouping and filtering of cache time objects"
-        type: integer
-        format: int32
-        example: 123
+        type: string
+        example: "123"
       release_time:
         description: "Release time in ISO-8601 format"
         type: string
@@ -123,9 +122,8 @@ definitions:
         example: "admin"
       collection_id:
         description: "Collection ID - used for grouping and filtering of cache time objects"
-        type: integer
-        format: int32
-        example: 123
+        type: string
+        example: "123"
       release_time:
         description: "Release time in ISO-8601 format"
         type: string

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -105,7 +105,7 @@ definitions:
       collection_id:
         description: "Collection ID - used for grouping and filtering of cache time objects"
         type: string
-        example: "123"
+        example: "example-1a19e3462937d85804752375daa00ba41d1b6625d396f21000e3c4571ebf2606"
       release_time:
         description: "Release time in ISO-8601 format"
         type: string
@@ -123,7 +123,7 @@ definitions:
       collection_id:
         description: "Collection ID - used for grouping and filtering of cache time objects"
         type: string
-        example: "123"
+        example: "example-1a19e3462937d85804752375daa00ba41d1b6625d396f21000e3c4571ebf2606"
       release_time:
         description: "Release time in ISO-8601 format"
         type: string


### PR DESCRIPTION
### What

Since florence passes string-type collection ID, the references to this field needed to be changed from integer type to string type across the repo

### How to review

Review the repo and confirm that all references to collection ID now expect/handle string type. Tests (unit/ component/ linting) should all run.

### Who can review

A member of ONS
