### PR TITLE
Upgrade go to 1.26.4

### DIFF
--- a/ci/build.yml
+++ b/ci/build.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.3-bookworm
+    tag: 1.26.4-bookworm
 
 inputs:
   - name: dp-legacy-cache-api

--- a/ci/component.yml
+++ b/ci/component.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-docker-go
-    tag: 1.26.3-dind-28
+    tag: 1.26.4-dind-28
 
 inputs:
   - name: dp-legacy-cache-api

--- a/ci/lint.yml
+++ b/ci/lint.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: onsdigital/dp-concourse-tools-lint-go-node
-    tag: 1.26.3-bookworm-golangci-lint-2-node-20
+    tag: 1.26.4-bookworm-golangci-lint-2-node-20
 
 inputs:
   - name: dp-legacy-cache-api

--- a/ci/unit.yml
+++ b/ci/unit.yml
@@ -6,7 +6,7 @@ image_resource:
   type: docker-image
   source:
     repository: golang
-    tag: 1.26.3-bookworm
+    tag: 1.26.4-bookworm
 
 inputs:
   - name: dp-legacy-cache-api


### PR DESCRIPTION
### What

The version of go has been increased from 1.26.3 to 1.26.4, to fix audit failures.

### How to review

Sense check. Tests pass.

### Who can review

Anyone.